### PR TITLE
Ai/migrations FIX when Connection would deleted, now the Conversation und Agent Version will not be deleted

### DIFF
--- a/Install/Sql/MsSQL/Migrations/1.31/202603111200_1_Drop_AgentVersionFK_From_AI_Conversation_ONDeleteNull.sql
+++ b/Install/Sql/MsSQL/Migrations/1.31/202603111200_1_Drop_AgentVersionFK_From_AI_Conversation_ONDeleteNull.sql
@@ -1,0 +1,82 @@
+-- UP
+DECLARE @fk_name NVARCHAR(128);
+DECLARE @sql NVARCHAR(MAX);
+
+SELECT TOP 1 @fk_name = fk.name
+FROM sys.foreign_keys fk
+         INNER JOIN sys.foreign_key_columns fkc
+                    ON fk.object_id = fkc.constraint_object_id
+         INNER JOIN sys.tables t_parent
+                    ON fkc.parent_object_id = t_parent.object_id
+         INNER JOIN sys.columns c_parent
+                    ON fkc.parent_object_id = c_parent.object_id
+                        AND fkc.parent_column_id = c_parent.column_id
+         INNER JOIN sys.tables t_ref
+                    ON fkc.referenced_object_id = t_ref.object_id
+         INNER JOIN sys.columns c_ref
+                    ON fkc.referenced_object_id = c_ref.object_id
+                        AND fkc.referenced_column_id = c_ref.column_id
+WHERE t_parent.name = 'exf_ai_agent_version'
+  AND c_parent.name = 'data_connection_default_oid'
+  AND t_ref.name = 'exf_data_connection'
+  AND c_ref.name = 'oid';
+
+IF @fk_name IS NOT NULL
+BEGIN
+    SET @sql = N'ALTER TABLE exf_ai_agent_version DROP CONSTRAINT [' + @fk_name + N']';
+EXEC sp_executesql @sql;
+END;
+
+ALTER TABLE exf_ai_agent_version
+ALTER COLUMN data_connection_default_oid BINARY(16) NULL;
+
+/* Verwaiste Referenzen bereinigen */
+UPDATE v
+SET v.data_connection_default_oid = NULL
+    FROM exf_ai_agent_version v
+LEFT JOIN exf_data_connection d
+ON v.data_connection_default_oid = d.oid
+WHERE v.data_connection_default_oid IS NOT NULL
+  AND d.oid IS NULL;
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.foreign_keys
+    WHERE name = 'fk_exf_ai_agent_version_data_connection_default_oid'
+)
+BEGIN
+ALTER TABLE exf_ai_agent_version
+    ADD CONSTRAINT fk_exf_ai_agent_version_data_connection_default_oid
+        FOREIGN KEY (data_connection_default_oid)
+            REFERENCES exf_data_connection(oid)
+            ON DELETE SET NULL;
+END;
+
+-- DOWN
+DECLARE @fk_name_down NVARCHAR(128);
+DECLARE @sql_down NVARCHAR(MAX);
+
+SELECT TOP 1 @fk_name_down = fk.name
+FROM sys.foreign_keys fk
+         INNER JOIN sys.foreign_key_columns fkc
+                    ON fk.object_id = fkc.constraint_object_id
+         INNER JOIN sys.tables t_parent
+                    ON fkc.parent_object_id = t_parent.object_id
+         INNER JOIN sys.columns c_parent
+                    ON fkc.parent_object_id = c_parent.object_id
+                        AND fkc.parent_column_id = c_parent.column_id
+         INNER JOIN sys.tables t_ref
+                    ON fkc.referenced_object_id = t_ref.object_id
+         INNER JOIN sys.columns c_ref
+                    ON fkc.referenced_object_id = c_ref.object_id
+                        AND fkc.referenced_column_id = c_ref.column_id
+WHERE t_parent.name = 'exf_ai_agent_version'
+  AND c_parent.name = 'data_connection_default_oid'
+  AND t_ref.name = 'exf_data_connection'
+  AND c_ref.name = 'oid';
+
+IF @fk_name_down IS NOT NULL
+BEGIN
+    SET @sql_down = N'ALTER TABLE exf_ai_agent_version DROP CONSTRAINT [' + @fk_name_down + N']';
+EXEC sp_executesql @sql_down;
+END;

--- a/Install/Sql/MsSQL/Migrations/1.31/20260311_1111_1_Drop_ConnectionFK_From_AI_Conversation_ONDeleteNull.sql
+++ b/Install/Sql/MsSQL/Migrations/1.31/20260311_1111_1_Drop_ConnectionFK_From_AI_Conversation_ONDeleteNull.sql
@@ -1,0 +1,82 @@
+-- UP
+DECLARE @fk_name NVARCHAR(128);
+DECLARE @sql NVARCHAR(MAX);
+
+SELECT TOP 1 @fk_name = fk.name
+FROM sys.foreign_keys fk
+         INNER JOIN sys.foreign_key_columns fkc
+                    ON fk.object_id = fkc.constraint_object_id
+         INNER JOIN sys.tables t_parent
+                    ON fkc.parent_object_id = t_parent.object_id
+         INNER JOIN sys.columns c_parent
+                    ON fkc.parent_object_id = c_parent.object_id
+                        AND fkc.parent_column_id = c_parent.column_id
+         INNER JOIN sys.tables t_ref
+                    ON fkc.referenced_object_id = t_ref.object_id
+         INNER JOIN sys.columns c_ref
+                    ON fkc.referenced_object_id = c_ref.object_id
+                        AND fkc.referenced_column_id = c_ref.column_id
+WHERE t_parent.name = 'exf_ai_conversation'
+  AND c_parent.name = 'connection_oid'
+  AND t_ref.name = 'exf_data_connection'
+  AND c_ref.name = 'oid';
+
+IF @fk_name IS NOT NULL
+BEGIN
+    SET @sql = N'ALTER TABLE exf_ai_conversation DROP CONSTRAINT [' + @fk_name + N']';
+EXEC sp_executesql @sql;
+END;
+
+ALTER TABLE exf_ai_conversation
+ALTER COLUMN connection_oid BINARY(16) NULL;
+
+/* Verwaiste Referenzen bereinigen */
+UPDATE c
+SET c.connection_oid = NULL
+    FROM exf_ai_conversation c
+LEFT JOIN exf_data_connection d
+ON c.connection_oid = d.oid
+WHERE c.connection_oid IS NOT NULL
+  AND d.oid IS NULL;
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.foreign_keys
+    WHERE name = 'fk_exf_ai_conversation_connection_oid'
+)
+BEGIN
+ALTER TABLE exf_ai_conversation
+    ADD CONSTRAINT fk_exf_ai_conversation_connection_oid
+        FOREIGN KEY (connection_oid)
+            REFERENCES exf_data_connection(oid)
+            ON DELETE SET NULL;
+END;
+
+-- DOWN
+DECLARE @fk_name_down NVARCHAR(128);
+DECLARE @sql_down NVARCHAR(MAX);
+
+SELECT TOP 1 @fk_name_down = fk.name
+FROM sys.foreign_keys fk
+         INNER JOIN sys.foreign_key_columns fkc
+                    ON fk.object_id = fkc.constraint_object_id
+         INNER JOIN sys.tables t_parent
+                    ON fkc.parent_object_id = t_parent.object_id
+         INNER JOIN sys.columns c_parent
+                    ON fkc.parent_object_id = c_parent.object_id
+                        AND fkc.parent_column_id = c_parent.column_id
+         INNER JOIN sys.tables t_ref
+                    ON fkc.referenced_object_id = t_ref.object_id
+         INNER JOIN sys.columns c_ref
+                    ON fkc.referenced_object_id = c_ref.object_id
+                        AND fkc.referenced_column_id = c_ref.column_id
+WHERE t_parent.name = 'exf_ai_conversation'
+  AND c_parent.name = 'connection_oid'
+  AND t_ref.name = 'exf_data_connection'
+  AND c_ref.name = 'oid';
+
+IF @fk_name_down IS NOT NULL
+BEGIN
+    SET @sql_down = N'ALTER TABLE exf_ai_conversation DROP CONSTRAINT [' + @fk_name_down + N']';
+EXEC sp_executesql @sql_down;
+END;

--- a/Install/Sql/MySQL/Migrations/1.31/202603111200_1_Drop_AgentVersionFK_From_AI_Conversation_ONDeleteNull.sql
+++ b/Install/Sql/MySQL/Migrations/1.31/202603111200_1_Drop_AgentVersionFK_From_AI_Conversation_ONDeleteNull.sql
@@ -1,0 +1,73 @@
+-- UP
+SET @fk_name := (
+    SELECT CONSTRAINT_NAME
+    FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'exf_ai_agent_version'
+      AND COLUMN_NAME = 'data_connection_default_oid'
+      AND REFERENCED_TABLE_NAME = 'exf_data_connection'
+      AND REFERENCED_COLUMN_NAME = 'oid'
+    LIMIT 1
+);
+
+SET @drop_sql := IF(
+    @fk_name IS NOT NULL,
+    CONCAT('ALTER TABLE exf_ai_agent_version DROP FOREIGN KEY `', @fk_name, '`'),
+    'SELECT 1'
+);
+
+PREPARE stmt FROM @drop_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+ALTER TABLE exf_ai_agent_version
+    MODIFY data_connection_default_oid BINARY(16) NULL;
+
+/* Verwaiste Referenzen bereinigen */
+UPDATE exf_ai_agent_version v
+    LEFT JOIN exf_data_connection d
+ON v.data_connection_default_oid = d.oid
+    SET v.data_connection_default_oid = NULL
+WHERE v.data_connection_default_oid IS NOT NULL
+  AND d.oid IS NULL;
+
+SET @create_sql := (
+    SELECT IF(
+        NOT EXISTS (
+            SELECT 1
+            FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+            WHERE CONSTRAINT_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'exf_ai_agent_version'
+              AND CONSTRAINT_NAME = 'fk_exf_ai_agent_version_data_connection_default_oid'
+              AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+        ),
+        'ALTER TABLE exf_ai_agent_version ADD CONSTRAINT fk_exf_ai_agent_version_data_connection_default_oid FOREIGN KEY (data_connection_default_oid) REFERENCES exf_data_connection(oid) ON DELETE SET NULL',
+        'SELECT 1'
+    )
+);
+
+PREPARE stmt2 FROM @create_sql;
+EXECUTE stmt2;
+DEALLOCATE PREPARE stmt2;
+
+-- DOWN
+SET @fk_name := (
+    SELECT CONSTRAINT_NAME
+    FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'exf_ai_agent_version'
+      AND COLUMN_NAME = 'data_connection_default_oid'
+      AND REFERENCED_TABLE_NAME = 'exf_data_connection'
+      AND REFERENCED_COLUMN_NAME = 'oid'
+    LIMIT 1
+);
+
+SET @drop_sql := IF(
+    @fk_name IS NOT NULL,
+    CONCAT('ALTER TABLE exf_ai_agent_version DROP FOREIGN KEY `', @fk_name, '`'),
+    'SELECT 1'
+);
+
+PREPARE stmt3 FROM @drop_sql;
+EXECUTE stmt3;
+DEALLOCATE PREPARE stmt3;

--- a/Install/Sql/MySQL/Migrations/1.31/20260311_1111_1_Drop_ConnectionFK_From_AI_Conversation_ONDeleteNull.sql
+++ b/Install/Sql/MySQL/Migrations/1.31/20260311_1111_1_Drop_ConnectionFK_From_AI_Conversation_ONDeleteNull.sql
@@ -1,0 +1,73 @@
+-- UP
+SET @fk_name := (
+    SELECT CONSTRAINT_NAME
+    FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'exf_ai_conversation'
+      AND COLUMN_NAME = 'connection_oid'
+      AND REFERENCED_TABLE_NAME = 'exf_data_connection'
+      AND REFERENCED_COLUMN_NAME = 'oid'
+    LIMIT 1
+);
+
+SET @drop_sql := IF(
+    @fk_name IS NOT NULL,
+    CONCAT('ALTER TABLE exf_ai_conversation DROP FOREIGN KEY `', @fk_name, '`'),
+    'SELECT 1'
+);
+
+PREPARE stmt FROM @drop_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+ALTER TABLE exf_ai_conversation
+    MODIFY connection_oid BINARY(16) NULL;
+
+/* Verwaiste Referenzen bereinigen */
+UPDATE exf_ai_conversation c
+    LEFT JOIN exf_data_connection d
+ON c.connection_oid = d.oid
+    SET c.connection_oid = NULL
+WHERE c.connection_oid IS NOT NULL
+  AND d.oid IS NULL;
+
+SET @create_sql := (
+    SELECT IF(
+        NOT EXISTS (
+            SELECT 1
+            FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+            WHERE CONSTRAINT_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'exf_ai_conversation'
+              AND CONSTRAINT_NAME = 'fk_exf_ai_conversation_connection_oid'
+              AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+        ),
+        'ALTER TABLE exf_ai_conversation ADD CONSTRAINT fk_exf_ai_conversation_connection_oid FOREIGN KEY (connection_oid) REFERENCES exf_data_connection(oid) ON DELETE SET NULL',
+        'SELECT 1'
+    )
+);
+
+PREPARE stmt2 FROM @create_sql;
+EXECUTE stmt2;
+DEALLOCATE PREPARE stmt2;
+
+-- DOWN
+SET @fk_name := (
+    SELECT CONSTRAINT_NAME
+    FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'exf_ai_conversation'
+      AND COLUMN_NAME = 'connection_oid'
+      AND REFERENCED_TABLE_NAME = 'exf_data_connection'
+      AND REFERENCED_COLUMN_NAME = 'oid'
+    LIMIT 1
+);
+
+SET @drop_sql := IF(
+    @fk_name IS NOT NULL,
+    CONCAT('ALTER TABLE exf_ai_conversation DROP FOREIGN KEY `', @fk_name, '`'),
+    'SELECT 1'
+);
+
+PREPARE stmt3 FROM @drop_sql;
+EXECUTE stmt3;
+DEALLOCATE PREPARE stmt3;

--- a/Install/Sql/PostgreSQL/Migrations/1.31/202603111200_1_Drop_AgentVersionFK_From_AI_Conversation_ONDeleteNull.sql
+++ b/Install/Sql/PostgreSQL/Migrations/1.31/202603111200_1_Drop_AgentVersionFK_From_AI_Conversation_ONDeleteNull.sql
@@ -1,0 +1,87 @@
+-- UP
+DO $$
+DECLARE
+fk_name text;
+BEGIN
+SELECT tc.constraint_name
+INTO fk_name
+FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu
+              ON tc.constraint_name = kcu.constraint_name
+                  AND tc.table_schema = kcu.table_schema
+         JOIN information_schema.constraint_column_usage ccu
+              ON tc.constraint_name = ccu.constraint_name
+                  AND tc.table_schema = ccu.table_schema
+WHERE tc.constraint_type = 'FOREIGN KEY'
+  AND tc.table_name = 'exf_ai_agent_version'
+  AND kcu.column_name = 'data_connection_default_oid'
+  AND ccu.table_name = 'exf_data_connection'
+  AND ccu.column_name = 'oid'
+    LIMIT 1;
+
+IF fk_name IS NOT NULL THEN
+        EXECUTE format(
+            'ALTER TABLE exf_ai_agent_version DROP CONSTRAINT %I',
+            fk_name
+        );
+END IF;
+END $$;
+
+/* Verwaiste Referenzen bereinigen */
+UPDATE exf_ai_agent_version v
+SET data_connection_default_oid = NULL
+WHERE v.data_connection_default_oid IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM exf_data_connection d
+    WHERE d.oid = v.data_connection_default_oid
+);
+
+ALTER TABLE exf_ai_agent_version
+    ALTER COLUMN data_connection_default_oid DROP NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE table_name = 'exf_ai_agent_version'
+          AND constraint_name = 'fk_exf_ai_agent_version_data_connection_default_oid'
+          AND constraint_type = 'FOREIGN KEY'
+    ) THEN
+ALTER TABLE exf_ai_agent_version
+    ADD CONSTRAINT fk_exf_ai_agent_version_data_connection_default_oid
+        FOREIGN KEY (data_connection_default_oid)
+            REFERENCES exf_data_connection(oid)
+            ON DELETE SET NULL;
+END IF;
+END $$;
+
+-- DOWN
+DO $$
+DECLARE
+fk_name text;
+BEGIN
+SELECT tc.constraint_name
+INTO fk_name
+FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu
+              ON tc.constraint_name = kcu.constraint_name
+                  AND tc.table_schema = kcu.table_schema
+         JOIN information_schema.constraint_column_usage ccu
+              ON tc.constraint_name = ccu.constraint_name
+                  AND tc.table_schema = ccu.table_schema
+WHERE tc.constraint_type = 'FOREIGN KEY'
+  AND tc.table_name = 'exf_ai_agent_version'
+  AND kcu.column_name = 'data_connection_default_oid'
+  AND ccu.table_name = 'exf_data_connection'
+  AND ccu.column_name = 'oid'
+    LIMIT 1;
+
+IF fk_name IS NOT NULL THEN
+        EXECUTE format(
+            'ALTER TABLE exf_ai_agent_version DROP CONSTRAINT %I',
+            fk_name
+        );
+END IF;
+END $$;

--- a/Install/Sql/PostgreSQL/Migrations/1.31/20260311_1111_1_Drop_ConnectionFK_From_AI_Conversation_ONDeleteNull.sql
+++ b/Install/Sql/PostgreSQL/Migrations/1.31/20260311_1111_1_Drop_ConnectionFK_From_AI_Conversation_ONDeleteNull.sql
@@ -1,0 +1,87 @@
+-- UP
+DO $$
+DECLARE
+fk_name text;
+BEGIN
+SELECT tc.constraint_name
+INTO fk_name
+FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu
+              ON tc.constraint_name = kcu.constraint_name
+                  AND tc.table_schema = kcu.table_schema
+         JOIN information_schema.constraint_column_usage ccu
+              ON tc.constraint_name = ccu.constraint_name
+                  AND tc.table_schema = ccu.table_schema
+WHERE tc.constraint_type = 'FOREIGN KEY'
+  AND tc.table_name = 'exf_ai_conversation'
+  AND kcu.column_name = 'connection_oid'
+  AND ccu.table_name = 'exf_data_connection'
+  AND ccu.column_name = 'oid'
+    LIMIT 1;
+
+IF fk_name IS NOT NULL THEN
+        EXECUTE format(
+            'ALTER TABLE exf_ai_conversation DROP CONSTRAINT %I',
+            fk_name
+        );
+END IF;
+END $$;
+
+/* Verwaiste Referenzen bereinigen */
+UPDATE exf_ai_conversation c
+SET connection_oid = NULL
+WHERE c.connection_oid IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM exf_data_connection d
+    WHERE d.oid = c.connection_oid
+);
+
+ALTER TABLE exf_ai_conversation
+    ALTER COLUMN connection_oid DROP NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE table_name = 'exf_ai_conversation'
+          AND constraint_name = 'fk_exf_ai_conversation_connection_oid'
+          AND constraint_type = 'FOREIGN KEY'
+    ) THEN
+ALTER TABLE exf_ai_conversation
+    ADD CONSTRAINT fk_exf_ai_conversation_connection_oid
+        FOREIGN KEY (connection_oid)
+            REFERENCES exf_data_connection(oid)
+            ON DELETE SET NULL;
+END IF;
+END $$;
+
+-- DOWN
+DO $$
+DECLARE
+fk_name text;
+BEGIN
+SELECT tc.constraint_name
+INTO fk_name
+FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu
+              ON tc.constraint_name = kcu.constraint_name
+                  AND tc.table_schema = kcu.table_schema
+         JOIN information_schema.constraint_column_usage ccu
+              ON tc.constraint_name = ccu.constraint_name
+                  AND tc.table_schema = ccu.table_schema
+WHERE tc.constraint_type = 'FOREIGN KEY'
+  AND tc.table_name = 'exf_ai_conversation'
+  AND kcu.column_name = 'connection_oid'
+  AND ccu.table_name = 'exf_data_connection'
+  AND ccu.column_name = 'oid'
+    LIMIT 1;
+
+IF fk_name IS NOT NULL THEN
+        EXECUTE format(
+            'ALTER TABLE exf_ai_conversation DROP CONSTRAINT %I',
+            fk_name
+        );
+END IF;
+END $$;


### PR DESCRIPTION
Wenn eine Connection gelöscht wurde, wurde ein Conversations und Agents gelöscht. Das wurde mit diesen Migrations repariert. Die beiden werden jetzt auf null gesetzt, falls eine Connection gelöscht wird.